### PR TITLE
2 Typos Fixed + Punctuation

### DIFF
--- a/src/gui-qt/mainwindow.ui
+++ b/src/gui-qt/mainwindow.ui
@@ -713,7 +713,7 @@
            <item>
             <widget class="QSpinBox" name="sbLineNoStart">
              <property name="toolTip">
-              <string>Set line numbering start</string>
+              <string>Set line numbering start.</string>
              </property>
              <property name="buttonSymbols">
               <enum>QAbstractSpinBox::UpDownArrows</enum>
@@ -802,7 +802,7 @@ Removes Unicode BOM mark.</string>
            <item>
             <widget class="QCheckBox" name="cbEncoding">
              <property name="toolTip">
-              <string>Set the output file ancoding.</string>
+              <string>Set the output file encoding.</string>
              </property>
              <property name="text">
               <string>Set encoding:</string>
@@ -1497,7 +1497,7 @@ You can select the stylesheets in your word processor to reformat additional tex
              <item>
               <widget class="QCheckBox" name="cbRTFPageColor">
                <property name="toolTip">
-                <string>Set page color attribute to background color</string>
+                <string>Set page color attribute to background color.</string>
                </property>
                <property name="text">
                 <string>Set page color</string>
@@ -1857,7 +1857,7 @@ You can select the stylesheets in your word processor to reformat additional tex
             <widget class="QCheckBox" name="cbReformat">
              <property name="toolTip">
               <string>Reformat and indent your code.
-This feature is enabled tor C, C++, C# and Java code.</string>
+This feature is enabled for C, C++, C# and Java code.</string>
              </property>
              <property name="text">
               <string>Reformat:</string>


### PR DESCRIPTION
Minor typos fixes in English GUI text: a "tor" instead of "for", "ancoding" inst. of "encoding".

Also added 2 missing fullstops in Tooltips, for consistency sake with other Tooltips punctuation style (Qt Linguist nags you when a translations doen't end with same punctuation as original, so it brought them to my attention during translation work).