### PR TITLE
Attempting to sync the Java language definition with the official language spec

### DIFF
--- a/langDefs/java.lang
+++ b/langDefs/java.lang
@@ -2,16 +2,17 @@ Description="Java"
 
 Keywords={
   { Id=1,
-    List={"abstract", "default", "if", "private", "this", "do", "implements",
-        "protected", "throw", "break", "import", "public", "throws", "else",
-        "instanceof", "return", "transient", "case", "extends", "try", "catch", "final",
-        "interface", "static", "finally", "strictfp", "volatile", "class", "native",
-        "super", "while", "const", "for", "new", "switch", "continue", "goto",
-        "package", "synchronized", "as", "in", "def", "property"}, },
-  { Id=2,
-    List={"boolean", "double", "byte", "int", "short", "void", "char", "long", "float"},
+    List={"abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const",
+          "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally",
+          "float", "for", "goto", "if", "implements", "import", "instanceof", "int", "interface",
+          "long", "native", "new", "package", "private", "protected", "public", "return", "short",
+          "static", "strictfp", "super", "switch", "synchronized", "this", "throw", "throws",
+          "transient", "try", "void", "volatile", "while"},
   },
- { Id=3,
+  { Id=2,
+    List={"false", "true", "null"},
+  },
+  { Id=3,
     Regex=[[@\w+]],
   },
   { Id=4,
@@ -39,4 +40,3 @@ Comments={
 Operators=[[\(|\)|\[|\]|\{|\}|\,|\;|\.|\:|\&|<|>|\!|\=|\/|\*|\%|\+|\-|\|]]
 
 EnableIndentation=true
-


### PR DESCRIPTION
Seems to fix issue #13. I also sorted the keywords and normalized indentation to appease my brain goblins.