### PR TITLE
add .html, .twig & .jinja to HTML & js shebang for node

### DIFF
--- a/filetypes.conf
+++ b/filetypes.conf
@@ -70,7 +70,7 @@ FileMapping = {
  { Lang="tex", Extensions={"sty", "cls"} },
  { Lang="vb", Extensions={"bas", "basic", "bi", "vbs"} },
  { Lang="verilog", Extensions={"v"} },
- { Lang="html", Extensions={"htm", "xhtml"} },
+ { Lang="html", Extensions={"htm", "xhtml", "html", "twig", "jinja"} },
  { Lang="xml", Extensions={"sgm", "sgml", "nrm", "ent","hdr", "hub", "dtd", "glade",
                "wml","vxml", "wml", "tld", "csproj","xsl", "ecf", "jnlp", "xsd", "resx"} },
  { Lang="fsharp", Extensions={"fs","fsx"} },
@@ -134,6 +134,7 @@ FileMapping = {
  { Lang="perl",  Shebang=[[^#!\s*(/usr)?(/local)?/bin/(env\s+)?perl]] },
  { Lang="python",  Shebang=[[^#!\s*(/usr)?(/local)?/bin/(env\s+)?python]] },
  { Lang="ruby",  Shebang=[[^#!\s*(/usr)?(/local)?/bin/(env\s+)?ruby]] },
- { Lang="php", Shebang=[[^#!\s*(/usr)?(/local)?/bin/(env\s+)?php]] }
+ { Lang="php", Shebang=[[^#!\s*(/usr)?(/local)?/bin/(env\s+)?php]] },
+ { Lang="js", Shebang=[[^#!\s*(/usr)?(/local)?/bin/(env\s+)?node]] }
 }
 


### PR DESCRIPTION
- `.html` because it's very common
- `.twig` for [twig](https://twig.symfony.com/) template language for `php`
- `.jinja` for [jinja](http://jinja.pocoo.org/docs/2.9/) template language for `python`

also added shebang for `node` scripts.

I have one question, any reason why these two lines are commented out in [`html.lang`](https://github.com/andre-simon/highlight/blob/master/langDefs/html.lang#L46-L47) enabling them can improve the highlighting for `jinja` & `twig` two. So I was wondering why they are commened out & if I should enable them or not.

Thanks for the amazing tool!