### PR TITLE
Add "Clean Slate" LangDef Boilerplate

### DIFF
--- a/extras/langDefs-resources/cleanslate.lang
+++ b/extras/langDefs-resources/cleanslate.lang
@@ -2,7 +2,7 @@
     *                                                                            *
     *          Highlight Language Definition "Clean Slate" Boilerplate           *
     *                                                                            *
-    *               v1.0.0 (2018/01/03) | Highlight v3.41 | Lua 5.3              *
+    *               v1.0.1 (2018/01/04) | Highlight v3.41 | Lua 5.3              *
     *                                                                            *
     *                             by Tristano Ajmone                             *
     *                                                                            *
@@ -59,7 +59,16 @@ EnableIndentation=false -- Syntax may be reformatted and indented? (true/false)
     Highlight's default Identifiers definition:
     Identifiers=[=[ [a-zA-Z_]\w* ]=]
 --]]
-Identifiers=[=[ \A(?!x)x ]=] -- Never-Matching RegEx!
+-- UNCOMMENT TO USE NEVER-MATCHING REGEX:
+-- Identifiers=[=[ \A(?!x)x ]=] -- Never-Matching RegEx!
+
+-- ** WARNING ** By setting Identifiers to a never-matching RegEx, Keywords lists
+--               won't be reckognized anymore by the parser! This can be a useful
+--               trick/hack needed in some syntax which rely only on RegEx-defined
+--               Keywords, and to avoid conflicts with other elements in some
+--               edge-cases. Try it only to check if the current (or default)
+--               Identifiers definition might be interfering in the parsing of
+--               other elements.
 
 --[[==============================================================================
                                        COMMENTS                                   
@@ -138,7 +147,19 @@ Strings={
   Interpolation=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
 }
 
+--[[==============================================================================
+                                     PREPROCESSOR                                 
+    ==============================================================================
+    PreProcessor = { Prefix, Continuation? }
 
+      Prefix:        String, regular expression which describes open delimiter
+      Continuation:  String, contains line continuation character (optional).
+--]]
+PreProcessor = {
+  Prefix=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+  -- UNCOMMENT IF YOU NEED CONTINUATION CHARACTER:
+  -- Continuation="", -- A character, not a RegEx! (escaping rules apply)
+}
 --[[==============================================================================
                                       OPERATORS                                   
     ==============================================================================
@@ -195,10 +216,24 @@ Keywords={
   }
 }
 
+--[[******************************************************************************
+    *                                                                            *
+    *                           CUSTOM HOOK-FUNCTIONS                            *
+    *                                                                            *
+    ******************************************************************************
+    In some cases you might need to gain finer control over Highlight parser; you
+    can do so by defininng some custom hooks via the OnStateChange() function.
+
+    For more info, see:
+    -- https://github.com/andre-simon/highlight/blob/master/README#L596
+    -- https://github.com/andre-simon/highlight/blob/master/README_PLUGINS#L170
+
+ --]]
+
 --[[==============================================================================
                                         CHANGELOG                                     
 ==================================================================================
- v1.0.0 (2018/01/03) | Highlight v3.41)
+ v1.0.1 (2018/01/04) | Highlight v3.41)
     - First release.
 --]]
 

--- a/extras/langDefs-resources/cleanslate.lang
+++ b/extras/langDefs-resources/cleanslate.lang
@@ -1,0 +1,204 @@
+--[[******************************************************************************
+    *                                                                            *
+    *          Highlight Language Definition "Clean Slate" Boilerplate           *
+    *                                                                            *
+    *               v1.0.0 (2018/01/03) | Highlight v3.41 | Lua 5.3              *
+    *                                                                            *
+    *                             by Tristano Ajmone                             *
+    *                                                                            *
+    ******************************************************************************
+    This is a langDef boilerplate intended as a starting point to build your own
+    custom language definition on top of it. This boilerplate is based on a "clean
+    slate" approach: all possible syntax elements definition are present, but they
+    are set to a never matching regular expression:
+
+        [=[ \A(?!x)x ]=]
+    
+    This boilerplate will never match anything; even Highlight's built-in defaults
+    are overridden (ie: those elements which, if undefined, would take fallback
+    default values). The idea is that of starting with a "clean slate" language
+    definition, where nothing is matched at all; and then start to build the lang
+    def one element definition after the other, without the potential interference
+    of any default definitions. This is a "distraction free" approach, which allows
+    to focus on single syntax elements in a "vacuum" environment, particularly
+    useful when dealing with syntax definitions where conflicts between various
+    elements arise. Once you've succeeded in defining a given syntax element, you
+    can comment it out and replace it with the original never matching RegEx, and
+    start working on the next element. Working on a single element at the time
+    prevents cross-elements interferences creeping in; and switching between an
+    element's real definition and it's never matching RegEx is a practical way to
+    isolate which element is interfering with others in the final context.
+
+    Just copy this boilerplate, rename it, and edit it as required. The language
+    definition template "template.lang" can be referenced for guidelines and useful
+    presets while working on your custom language -- the template contains useful
+    comments and preset examples on the various syntax elements. The comments in
+    this boilerplate have been kept down to the essential references for this
+    context; for more details refer to "template.lang" comments and the official
+    documentation.
+    ------------------------------------------------------------------------------
+    Written by Tristano Ajmone:
+        <tajmone@gmail.com>
+        https://github.com/tajmone
+    Released into the public domain according to the Unlicense terms:
+        http://unlicense.org/
+    ------------------------------------------------------------------------------
+--]]
+
+Description="Clean Slate" -- Syntax description
+
+IgnoreCase=false -- Are keywords case-sensitive? (true/false)
+
+EnableIndentation=false -- Syntax may be reformatted and indented? (true/false)
+
+--[[==============================================================================
+                                     IDENTIFIERS                                  
+    ==============================================================================
+    String, Regular expression which defines identifiers (optional).
+
+    Highlight's default Identifiers definition:
+    Identifiers=[=[ [a-zA-Z_]\w* ]=]
+--]]
+Identifiers=[=[ \A(?!x)x ]=] -- Never-Matching RegEx!
+
+--[[==============================================================================
+                                       COMMENTS                                   
+    ==============================================================================
+    Comments = { {Block, Nested?, Delimiter=} }
+
+      Block:     Boolean, true if comment is a block comment
+      Nested:    Boolean, true if block comments can be nested (optional)
+      Delimiter: List, contains open delimiter regex (line comment) or open and
+                 close delimiter regexes (block comment)
+--]]
+Comments={
+  -- Define BLOCK-COMMENTS delimiters
+  { Block=true,
+    Nested=false, -- Can block comments be nested? (optional)
+    Delimiter = {
+      [=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+      [=[ \A(?!x)x ]=]  -- Never-Matching RegEx!
+    }
+  },
+  -- Define SINGLE-LINE-COMMENTS delimiter
+  { Block=false,
+    Delimiter = { [=[ \A(?!x)x ]=] } -- Never-Matching RegEx!
+  }
+}
+--[[==============================================================================
+                                       STRINGS                                    
+    ==============================================================================
+    Strings = { Delimiter|DelimiterPairs={Open, Close, Raw?}, Escape?, Interpolation?,
+                RawPrefix?, AssertEqualLength? }
+
+      Delimiter:         String, regular expression which describes string delimiters
+      DelimiterPairs:    List, includes open and close delimiter expressions if not
+                         equal, includes optional Raw flag as boolean which marks
+                         delimiter pair to contain a raw string
+      Escape:            String, regex of escape sequences (optional)
+      Interpolation:     String, regex of interpolation sequences (optional)
+      RawPrefix:         String, defines raw string indicator (optional)
+      AssertEqualLength: Boolean, set true if delimiters must have the same length
+--]]
+Strings={
+
+  --------------------------------------------------------------------------------
+  --                              STRING DELIMITERS                               
+  --------------------------------------------------------------------------------
+
+  -- SYMMETRICAL STRINGS DELIMITERS
+  Delimiter=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+
+  -- ASSYMMETRICAL STRINGS DELIMITERS
+  DelimiterPairs= {
+    { Open= [=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+      Close=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+      Raw=true, -- Are these raw string delimiters? (true/false)
+    }
+  },
+  AssertEqualLength=true, -- Delimiters must have the same length?
+
+  -- RAW-STRING PREFIX (if language supports it)
+  RawPrefix=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+--[==[----------------------------------------------------------------------------
+                                 ESCAPE SEQUENCES                               
+  --------------------------------------------------------------------------------
+  If the language at hand supports escape sequences, define a RegEx pattern to
+  capture them.
+
+  Highlight's default built-in Escape definition:
+  Escape=[=[ \\u[[:xdigit:]]{4}|\\\d{3}|\\x[[:xdigit:]]{2}|\\[ntvbrfa\\\?'"] ]=]
+--]==]
+  Escape=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+--[[------------------------------------------------------------------------------
+                                  INTERPOLATION                                 
+    ------------------------------------------------------------------------------
+    String, regex of interpolation sequences (optional)
+--]]
+  Interpolation=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+}
+
+
+--[[==============================================================================
+                                      OPERATORS                                   
+    ==============================================================================
+--]]
+Operators=[=[ \A(?!x)x ]=] -- Never-Matching RegEx!
+
+--[[==============================================================================
+                                        DIGITS                                    
+    ==============================================================================
+    String, Regular expression which defines digits (optional).
+
+    Highlight's default built-in Digits definition:
+    Digits=[=[ (?:0x|0X)[0-9a-fA-F]+|\d*[\.]?\d+(?:[eE][\-\+]\d+)?[lLuU]* ]=]
+--]]
+Digits=[=[ \A(?!x)x ]=] -- Never-Matching RegEx!
+
+--[[==============================================================================
+                                       KEYWORDS                                   
+    ==============================================================================
+    Keywords = { Id, List|Regex, Group? }
+
+      Id:    Integer, keyword group id (values 1-4, can be reused for several keyword
+              groups)
+      List:  List, list of keywords
+      Regex: String, regular expression
+      Group: Integer, capturing group id of regular expression, defines part of regex
+             which should be returned as keyword (optional; if not set, the match
+             with the highest group number is returned (counts from left to right))
+
+    NOTE: Keyword group Ids are not limited to 4, you can create as many as you
+          need; but bare in mind that most themes that ship with Highlight usually
+          provide definitions only for Ids 1-4, so in order to syntax-color Keyword
+          groups with Ids greater than 4 you'll need to define a theme that covers
+          their definitions.
+
+--]]
+
+Keywords={
+  --------------------------------------------------------------------------------
+  --                               Keywords by List                               
+  --------------------------------------------------------------------------------
+  { Id=1,
+    List={
+      -- Keywords list
+      "XYZ", "ZYX" -- Dummy Sample Values
+    }
+  },
+  --------------------------------------------------------------------------------
+  --                              Keywords by RegEx                               
+  --------------------------------------------------------------------------------
+  { Id=2,
+    Regex=[=[ \A(?!x)x ]=], -- Never-Matching RegEx!
+    Group=1
+  }
+}
+
+--[[==============================================================================
+                                        CHANGELOG                                     
+==================================================================================
+ v1.0.0 (2018/01/03) | Highlight v3.41)
+    - First release.
+--]]
+

--- a/extras/langDefs-resources/template.lang
+++ b/extras/langDefs-resources/template.lang
@@ -2,7 +2,7 @@
     *                                                                            *
     *                   Highlight Language Definition Template                   *
     *                                                                            *
-    *               v1.0.2 (2018/01/03) | Highlight v3.41 | Lua 5.3              *
+    *               v1.0.3 (2018/01/04) | Highlight v3.41 | Lua 5.3              *
     *                                                                            *
     *                             by Tristano Ajmone                             *
     *                                                                            *
@@ -176,7 +176,31 @@ Strings={
   Interpolation=[=[ \$\{.+?\} ]=], -- Javascript Interpolation: ${ ... }
 }
 
+--[[==============================================================================
+                                     PREPROCESSOR                                 
+    ==============================================================================
+    PreProcessor = { Prefix, Continuation? }
 
+      Prefix:        String, regular expression which describes open delimiter
+      Continuation:  String, contains line continuation character (optional).
+
+    NOTE: This element is treated by Highlight parser in a similar way to single-
+          line comments: it swallows up everything from the matching Prefix up to
+          the end of the line -- but unlike comment lines (which can't contain
+          further syntax elements), the parser will still be looking for some 
+          syntax elements (in the current line) which might be reasonably found
+          within a line of preprocessor directives (eg: strings and comments);
+          but once these elements are dealt with, the parser will resume the 
+          PreProcessor state to carry on parsing the rest of the line.
+
+          Furthermore, the Continuation character allows this element to span
+          across multiple line (without the need of an opening and closing pair,
+          unlike multiline comments do).
+--]]
+PreProcessor = {  -- C/C++ PreProcessor example:
+  Prefix=[=[ # ]=],  -- Hash char ('#') marks beginning of preprocessor line
+  Continuation="\\", -- Backslash ('\') marks continuation of preprocessor line
+}
 --[[==============================================================================
                                       OPERATORS                                   
     ==============================================================================
@@ -370,7 +394,7 @@ end
 --[[==============================================================================
                                         CHANGELOG                                     
 ==================================================================================
- v1.0.2 (2018/01/03 | Highlight v3.41)
+ v1.0.3 (2018/01/04 | Highlight v3.41)
     - Minor tweaks.
  v1.0.1 (2017/11/19 | Highlight v3.40)
     - HIGHLIGHT DEFAULTS FIX: Add `Escape` to list of default definitions, as well

--- a/extras/langDefs-resources/template.lang
+++ b/extras/langDefs-resources/template.lang
@@ -2,7 +2,7 @@
     *                                                                            *
     *                   Highlight Language Definition Template                   *
     *                                                                            *
-    *               v1.0.1 (2017/11/19) | Highlight v3.40 | Lua 5.3              *
+    *               v1.0.2 (2018/01/03) | Highlight v3.41 | Lua 5.3              *
     *                                                                            *
     *                             by Tristano Ajmone                             *
     *                                                                            *
@@ -21,6 +21,12 @@
 
     Hopefully, this template will help both those creating their first langDef as
     well as experienced users.
+    ------------------------------------------------------------------------------
+    ** HOW TO DISABLE SYNTAX ELEMENTS **
+    If you wish to suppress a syntax element, you can assign a never matching
+    regular expression to its definition (thanks to André Simon for the tip):
+
+        [=[ \A(?!x)x ]=]
     ------------------------------------------------------------------------------
     ** MANDATORY ELEMENTS **
     The bare minimum definitions required for a langDef file to be valid are:
@@ -124,15 +130,16 @@ Strings={
   DelimiterPairs= {
     { Open= [=[ \[=*\[ ]=],  -- [[  [=[  [===[   etc.
       Close=[=[ \]=*\] ]=],  -- ]]  ]=]  ]===]   etc.
-      Raw=true }
+      Raw=true, -- Are these raw string delimiters? (true/false)
+    }
   },
   AssertEqualLength=true,  -- Delimiters must have the same length?
 
   -- RAW-STRING PREFIX (if language supports it)
   RawPrefix="R",           -- Raw string indicator (optional): R (C style)
 --[[------------------------------------------------------------------------------
-                                 ESCAPE SEQUENCES                               
-  ------------------------------------------------------------------------------
+                                ESCAPE SEQUENCES                               
+  --------------------------------------------------------------------------------
   If the language at hand supports escape sequences, define a RegEx pattern to
   capture them.
 
@@ -363,6 +370,8 @@ end
 --[[==============================================================================
                                         CHANGELOG                                     
 ==================================================================================
+ v1.0.2 (2018/01/03 | Highlight v3.41)
+    - Minor tweaks.
  v1.0.1 (2017/11/19 | Highlight v3.40)
     - HIGHLIGHT DEFAULTS FIX: Add `Escape` to list of default definitions, as well
       as its RegEx string as proposed preset.


### PR DESCRIPTION
New "`cleanslate.lang`" boilerplate: this langDef defines all possible syntax elements with never-matching RegExs, so that no elements ever match. Also overrides Highlight default fallback definitions. This allows to work with a clean slate approach, defining one syntax element at the time.

"`template.lang`" v1.0.2 (minor tweaks).