### PR TITLE
Haskell: Fix single-quoted strings that are also identifiers

### DIFF
--- a/langDefs/haskell.lang
+++ b/langDefs/haskell.lang
@@ -101,7 +101,7 @@ Strings={
 
 -- Escape sequences only occur inside strings
 function OnStateChange(oldState, newState, token, kwgroup)
-  if newState==HL_ESC_SEQ and oldState~=HL_STRING then
+  if newState==HL_ESC_SEQ and oldState~=HL_STRING or string.match(token, "%a+'" ) and oldState==HL_STRING then
     return HL_REJECT
   end
   return newState


### PR DESCRIPTION
As per andre-simon's suggestion in issue #48.