### PR TITLE
Fix Polygen Name

### DIFF
--- a/langDefs/ebnf2.lang
+++ b/langDefs/ebnf2.lang
@@ -2,7 +2,7 @@
     *                                                                           *
     *                          EBNF2 Syntax Definition                          *
     *                                                                           *
-    *              v1.0.0 (2018/01/14) | Highlight v3.41 | Lua 5.3              *
+    *              v1.0.1 (2018/01/18) | Highlight v3.41 | Lua 5.3              *
     *                                                                           *
     *                             by Tristano Ajmone                            *
     *                                                                           *
@@ -11,11 +11,11 @@
     Syntax type: EBNF (Extended Backus–Naur form)
     -----------------------------------------------------------------------------
     I've created this EBNF syntax definition because I needed to syntax highlight
-    the EBNF code of PolyGen Manual, which wasn't being handled properly by the
+    the EBNF code of Polygen Manual, which wasn't being handled properly by the
     existing Highlight *BNF definitions ("ebnf", "abnf", and "bnf"). So I decided
-    to create my own EBNF syntax by adapting the PolyGen Grammars syntax I had
+    to create my own EBNF syntax by adapting the Polygen Grammars syntax I had
     just recently created. Some tweaks were required to make it parse properly
-    the EBNF code found in the PolyGen Manual (see changelog, at the end).
+    the EBNF code found in the Polygen Manual (see changelog, at the end).
 
     Hopefully others might benefit from this new EBNF syntax too. Since there is
     no universal standard for EBNF notation (EBNF being a family of notations),
@@ -100,6 +100,9 @@ Keywords={
 --[[=============================================================================
                                        CHANGELOG
 =================================================================================
+ v1.0.1 (2018/01/18) | Highlight v3.41)
+    - Changed "PolyGen" to "Polygen" (the author has now officially adopted the
+      latter syntax).
  v1.0.0 (2018/01/14) | Highlight v3.41)
     - First release. Created by modifying "polygen.lang" (v1.0.0):
       - Suppressed Escape Sequences (via Never-Matching RegEx)

--- a/langDefs/polygen.lang
+++ b/langDefs/polygen.lang
@@ -1,8 +1,8 @@
 --[[*****************************************************************************
     *                                                                           *
-    *                     PolyGen Grammars Syntax Definition                    *
+    *                     Polygen Grammars Syntax Definition                    *
     *                                                                           *
-    *               v1.0.0 (2018/01/04) | Highlight v3.41 | Lua 5.3             *
+    *               v1.0.1 (2018/01/18) | Highlight v3.41 | Lua 5.3             *
     *                                                                           *
     *                             by Tristano Ajmone                            *
     *                                                                           *
@@ -10,25 +10,25 @@
     Associated file extensions: ".grm"
     Syntax type: EBNF
     -----------------------------------------------------------------------------
-    PolyGen is a cross-platform command line tool for generating random sentences
+    Polygen is a cross-platform command line tool for generating random sentences
     according to a grammar definition -- ie: following custom syntactical and
     lexical rules. It takes an Ascii text file ("*.grm") as source program defining
     a grammar by means of EBNF-like probabilistic rules and executes it. At each
     execution, the grammar will be run against different random seeds, therefore
     producing a different text output.
 
-    The main goal of PolyGen is to generate cursory nonsense for entertainment;
+    The main goal of Polygen is to generate cursory nonsense for entertainment;
     or, in the words of its author, "a first effort towards satyre in computer
-    science". PolyGen was created by Alvise Spanò.
+    science". Polygen was created by Alvise Spanò.
 
-    PolyGen Website and GitHub repository:
+    Polygen Website and GitHub repository:
         http://www.polygen.org/
         https://github.com/alvisespano/Polygen
 
-    PolyGen grammars documentation (in Italian):
+    Polygen grammars documentation (in Italian):
         http://www.polygen.org/it/manuale
 
-    An outdated English translation (probably from an earlier version of PolyGen,
+    An outdated English translation (probably from an earlier version of Polygen,
     since it doesn't cover the full syntax) can be found at:
         http://lapo.it/polygen/polygen-1.0.6-20040705-doc.zip
     -----------------------------------------------------------------------------
@@ -39,7 +39,7 @@
         http://unlicense.org/
     -----------------------------------------------------------------------------
 --]]
-Description="PolyGen"
+Description="Polygen"
 
 IgnoreCase=false
 EnableIndentation=false
@@ -48,7 +48,7 @@ EnableIndentation=false
 ---------------------------------------------------------------------------------
 NEVER_MATCH_RE=[=[ \A(?!x)x ]=] -- A Never-Matching RegEx!
 
-Digits=NEVER_MATCH_RE -- Numbers are just text in PolyGen!
+Digits=NEVER_MATCH_RE -- Numbers are just text in Polygen!
 
 Identifiers=NEVER_MATCH_RE -- Highlight's default Identifiers RegEx prevents
 -- capturing the Epsilon operator ('_'). Since in this syntax, all identifiers
@@ -77,7 +77,7 @@ Strings={
   -------------------------------------------------------------------------------
   --                             STRING DELIMITERS
   -------------------------------------------------------------------------------
-  -- PolyGen reckognises only double quotes as string delimiter: "...STRING..."
+  -- Polygen reckognises only double quotes as string delimiter: "...STRING..."
   Delimiter=[=[ " ]=],
 --[[-----------------------------------------------------------------------------
                                   ESCAPE SEQUENCES
@@ -110,7 +110,7 @@ Keywords={
   -- as a label (eg: 'S::=` and 'X:=`, instead of 'S ::=` and 'X :=`) because of
   -- the colon; and a label with spaces before the colon will be parsed as a non-
   -- terminal symbol (eg: 'Label :' instead of 'Label:'). Since both usages are
-  -- considered bad (albeit valid) styles in PolyGen grammars (and indeed are 
+  -- considered bad (albeit valid) styles in Polygen grammars (and indeed are 
   -- rarely found in actual gramamrs), it's not worth implementing complex RegExs
   -- to capture such edge cases.
   -------------------------------------------------------------------------------
@@ -161,6 +161,9 @@ end
 --[[==============================================================================
                                         CHANGELOG
 ==================================================================================
+ v1.0.1 (2018/01/18) | Highlight v3.41)
+    - Changed "PolyGen" to "Polygen" (the author has now officially adopted the
+      latter syntax).
  v1.0.0 (2018/01/04) | Highlight v3.41)
     - First release.
 --]]


### PR DESCRIPTION
Last minute change before merging into official distribution: Since today, Polygen author has announced that the official spelling is "Polygen" (and not "PolyGen", as it was often refered to in the past). So, just fixing the name where it occurs.