### PR TITLE
fix directories passed to qmake being ignored

### DIFF
--- a/src/gui-qt/highlight.pro
+++ b/src/gui-qt/highlight.pro
@@ -43,13 +43,13 @@ unix {
     PKGCONFIG += lua
 
     # to make it run within Qt Creator
-    !contains(DEFINES, DATA_DIR) {
+    !contains(DEFINES, DATA_DIR.*) {
         DEFINES+=DATA_DIR=\\\"/usr/share/highlight/\\\"
     }
-    !contains(DEFINES, CONFIG_DIR) {
+    !contains(DEFINES, CONFIG_DIR.*) {
         DEFINES+=CONFIG_DIR=\\\"/etc/highlight/\\\"
     }
-    !contains(DEFINES, DOC_DIR) {
+    !contains(DEFINES, DOC_DIR.*) {
         DEFINES+=DOC_DIR=\\\"/usr/share/doc/highlight/\\\"
     }
 }


### PR DESCRIPTION
contains() matches the whole value, add regular expressions for the path
components.

-------

Test with:

```highlight/src/gui-qt $ qmake DEFINES=DOC_DIR=/foo```

Before:
```
highlight/src/gui-qt $ grep DDOC_DIR Makefile 
DEFINES       = -DDOC_DIR=/foo -DO2 -DQT -DDATA_DIR=\"/usr/share/highlight/\" -DCONFIG_DIR=\"/etc/highlight/\" -DDOC_DIR=\"/usr/share/doc/highlight/\" -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB
```
After:
```
highlight/src/gui-qt $ grep DDOC_DIR Makefile 
DEFINES       = -DDOC_DIR=/foo -DO2 -DQT -DDATA_DIR=\"/usr/share/highlight/\" -DCONFIG_DIR=\"/etc/highlight/\" -DQT_NO_DEBUG -DQT_WIDGETS_LIB -DQT_GUI_LIB -DQT_CORE_LIB
```
